### PR TITLE
'한우 상품'에 대한 CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok:1.18.16'
+	annotationProcessor 'org.projectlombok:lombok:1.18.16'
 }
 
 tasks.named('test') {

--- a/src/main/java/mj/oop/application/KoreanBeefCreateService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefCreateService.java
@@ -16,6 +16,6 @@ public class KoreanBeefCreateService implements ProductCreateService<KoreanBeef>
     }
     @Override
     public KoreanBeef create(KoreanBeef product) {
-        return new KoreanBeef(1L, "세상에서 제일 맛있는 한우", new BigDecimal(1000), "1+");
+        return repository.save(product);
     }
 }

--- a/src/main/java/mj/oop/application/KoreanBeefCreateService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefCreateService.java
@@ -1,0 +1,21 @@
+package mj.oop.application;
+
+import mj.oop.application.interfaces.ProductCreateService;
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+public class KoreanBeefCreateService implements ProductCreateService<KoreanBeef> {
+    private final KoreanBeefJpaRepository repository;
+
+    public KoreanBeefCreateService(KoreanBeefJpaRepository repository) {
+        this.repository = repository;
+    }
+    @Override
+    public KoreanBeef create(KoreanBeef product) {
+        return new KoreanBeef(1L, "세상에서 제일 맛있는 한우", new BigDecimal(1000), "1+");
+    }
+}

--- a/src/main/java/mj/oop/application/KoreanBeefDeleteService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefDeleteService.java
@@ -4,6 +4,8 @@ import mj.oop.application.interfaces.ProductDeleteService;
 import mj.oop.infra.KoreanBeefJpaRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
 
 @Service
 public class KoreanBeefDeleteService implements ProductDeleteService {
@@ -15,5 +17,10 @@ public class KoreanBeefDeleteService implements ProductDeleteService {
 
     @Override
     public void deleteBy(Long id) {
+        if (!repository.existsById(id)) {
+            throw new NoSuchElementException(id.toString());
+        }
+
+        repository.deleteById(id);
     }
 }

--- a/src/main/java/mj/oop/application/KoreanBeefDeleteService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefDeleteService.java
@@ -1,0 +1,19 @@
+package mj.oop.application;
+
+import mj.oop.application.interfaces.ProductDeleteService;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class KoreanBeefDeleteService implements ProductDeleteService {
+    private final KoreanBeefJpaRepository repository;
+
+    public KoreanBeefDeleteService(KoreanBeefJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void deleteBy(Long id) {
+    }
+}

--- a/src/main/java/mj/oop/application/KoreanBeefShowService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefShowService.java
@@ -6,6 +6,7 @@ import mj.oop.infra.KoreanBeefJpaRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 public class KoreanBeefShowService implements ProductShowService<KoreanBeef> {
@@ -18,5 +19,11 @@ public class KoreanBeefShowService implements ProductShowService<KoreanBeef> {
     @Override
     public List<KoreanBeef> showAll() {
         return repository.findAll();
+    }
+
+    @Override
+    public KoreanBeef showBy(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException(id.toString()));
     }
 }

--- a/src/main/java/mj/oop/application/KoreanBeefShowService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefShowService.java
@@ -1,0 +1,20 @@
+package mj.oop.application;
+
+import mj.oop.application.interfaces.ProductShowService;
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+
+import java.util.List;
+
+public class KoreanBeefShowService implements ProductShowService<KoreanBeef> {
+    private final KoreanBeefJpaRepository repository;
+
+    public KoreanBeefShowService(KoreanBeefJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<KoreanBeef> showAll() {
+        return repository.findAll();
+    }
+}

--- a/src/main/java/mj/oop/application/KoreanBeefShowService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefShowService.java
@@ -3,9 +3,11 @@ package mj.oop.application;
 import mj.oop.application.interfaces.ProductShowService;
 import mj.oop.domain.entity.KoreanBeef;
 import mj.oop.infra.KoreanBeefJpaRepository;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class KoreanBeefShowService implements ProductShowService<KoreanBeef> {
     private final KoreanBeefJpaRepository repository;
 

--- a/src/main/java/mj/oop/application/KoreanBeefUpdateService.java
+++ b/src/main/java/mj/oop/application/KoreanBeefUpdateService.java
@@ -1,0 +1,30 @@
+package mj.oop.application;
+
+import mj.oop.application.interfaces.ProductUpdateService;
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+
+import java.util.NoSuchElementException;
+
+public class KoreanBeefUpdateService implements ProductUpdateService<KoreanBeef> {
+    private final KoreanBeefJpaRepository repository;
+
+    public KoreanBeefUpdateService(KoreanBeefJpaRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public KoreanBeef update(Long id, KoreanBeef product) {
+        if (!repository.existsById(id)) {
+            throw new NoSuchElementException(id.toString());
+        }
+
+        KoreanBeef productUpdating = KoreanBeef.builder()
+                .id(product.getId())
+                .name(product.getName())
+                .price(product.getPrice())
+                .meatGrade(product.getMeatGrade()).build();
+
+        return repository.save(productUpdating);
+    }
+}

--- a/src/main/java/mj/oop/application/interfaces/ProductCreateService.java
+++ b/src/main/java/mj/oop/application/interfaces/ProductCreateService.java
@@ -1,0 +1,22 @@
+package mj.oop.application.interfaces;
+
+import mj.oop.application.KoreanBeefCreateService;
+import mj.oop.domain.entity.Product;
+
+/**
+ * Product 타입을 상속하는 객체의 생성에 대한 비지니스 로직을 처리한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefCreateService
+ * </p>
+ */
+public interface ProductCreateService<T extends Product> {
+    /**
+     * Product 타입을 상속하는 객체 생성하고, 생성된 객체를 반환한다.
+     * <p>
+     * @param product Product 타입을 상속하는 객체
+     * @return Product 타입을 상속하는 객체
+     * </p>
+     */
+    T create(T product);
+}

--- a/src/main/java/mj/oop/application/interfaces/ProductDeleteService.java
+++ b/src/main/java/mj/oop/application/interfaces/ProductDeleteService.java
@@ -1,0 +1,21 @@
+package mj.oop.application.interfaces;
+
+import mj.oop.application.KoreanBeefDeleteService;
+
+
+/**
+ * Product 타입 객체의 삭제에 대한 비지니스 로직을 처리한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefDeleteService
+ * </p>
+ */
+public interface ProductDeleteService {
+    /**
+     * 매개변수로 전달 받은 id에 해당하는 Product 타입 객체를 삭제한다
+     * <p>
+     * @param id Product 타입 상속 객체의 Id
+     * </p>
+     */
+    void deleteBy(Long id);
+}

--- a/src/main/java/mj/oop/application/interfaces/ProductShowService.java
+++ b/src/main/java/mj/oop/application/interfaces/ProductShowService.java
@@ -1,0 +1,21 @@
+package mj.oop.application.interfaces;
+
+import mj.oop.domain.entity.Product;
+
+import java.util.List;
+
+/**
+ * Product 타입을 상속하는 객체의 조회에 대한 비지니스 로직을 처리한다
+ * <p>
+ * All Known Implementing Classes:
+ * </p>
+ */
+public interface ProductShowService<T extends Product> {
+    /**
+     * Product 타입 상속 객체를 List 형태로 반환한다
+     * <p>
+     * @return Product 타입 상속 객체를 내부 요소로 하는 List Collection
+     * </p>
+     */
+    List<T> showAll();
+}

--- a/src/main/java/mj/oop/application/interfaces/ProductShowService.java
+++ b/src/main/java/mj/oop/application/interfaces/ProductShowService.java
@@ -18,4 +18,13 @@ public interface ProductShowService<T extends Product> {
      * </p>
      */
     List<T> showAll();
+
+    /**
+     * 매개변수로 전달 받은 id에 해당하는 Product 타입 상속 객체를 반환한다
+     * <p>
+     * @param id Product 타입 상속 객체의 Id
+     * @return Product 타입 상속 객체
+     * </p>
+     */
+    T showBy(Long id);
 }

--- a/src/main/java/mj/oop/application/interfaces/ProductUpdateService.java
+++ b/src/main/java/mj/oop/application/interfaces/ProductUpdateService.java
@@ -1,0 +1,23 @@
+package mj.oop.application.interfaces;
+
+import mj.oop.application.KoreanBeefUpdateService;
+import mj.oop.domain.entity.Product;
+
+/**
+ * Product 타입을 상속하는 객체의 수정에 대한 비지니스 로직을 처리한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefUpdateService
+ * </p>
+ */
+public interface ProductUpdateService<T extends Product> {
+    /**
+     * Product 타입을 상속하는 객체 수정하고, 수정된 객체를 반환한다.
+     * <p>
+     * @param id      Product 타입 객체의 Id
+     * @param product Product 타입 객체
+     * @return Product 타입 객체
+     * </p>
+     */
+    T update(Long id, T product);
+}

--- a/src/main/java/mj/oop/controller/ControllerExceptionAdvice.java
+++ b/src/main/java/mj/oop/controller/ControllerExceptionAdvice.java
@@ -1,0 +1,20 @@
+package mj.oop.controller;
+
+import mj.oop.controller.dto.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.NoSuchElementException;
+
+@ResponseBody
+@ControllerAdvice
+public class ControllerExceptionAdvice {
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NoSuchElementException.class)
+    public ExceptionResponse handleProductNotFound() {
+        return new ExceptionResponse("Product Not Found");
+    }
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.math.BigDecimal;
 
 @RestController
@@ -16,7 +17,7 @@ public class KoreanBeefCreateController implements ProductCreateController<Korea
     @PostMapping("/beef")
     @ResponseStatus(HttpStatus.CREATED)
     @Override
-    public KoreanBeefResponseData create(@RequestBody KoreanBeefRequestData requestDto) {
+    public KoreanBeefResponseData create(@RequestBody @Valid KoreanBeefRequestData requestDto) {
         return new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(1000), "1+");
     }
 }

--- a/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
@@ -1,8 +1,12 @@
 package mj.oop.controller;
 
+import mj.oop.application.KoreanBeefCreateService;
+import mj.oop.application.interfaces.ProductCreateService;
+import mj.oop.application.interfaces.ProductShowService;
 import mj.oop.controller.dto.KoreanBeefRequestData;
 import mj.oop.controller.dto.KoreanBeefResponseData;
 import mj.oop.controller.interfaces.ProductCreateController;
+import mj.oop.domain.entity.KoreanBeef;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,10 +18,17 @@ import java.math.BigDecimal;
 
 @RestController
 public class KoreanBeefCreateController implements ProductCreateController<KoreanBeefResponseData, KoreanBeefRequestData> {
+    private final ProductCreateService<KoreanBeef> service;
+
+    public KoreanBeefCreateController(KoreanBeefCreateService service) {
+        this.service = service;
+    }
+
     @PostMapping("/beef")
     @ResponseStatus(HttpStatus.CREATED)
     @Override
     public KoreanBeefResponseData create(@RequestBody @Valid KoreanBeefRequestData requestDto) {
-        return new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(1000), "1+");
+        KoreanBeef product = service.create(requestDto.toEntity());
+        return KoreanBeefResponseData.from(product);
     }
 }

--- a/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefCreateController.java
@@ -1,0 +1,22 @@
+package mj.oop.controller;
+
+import mj.oop.controller.dto.KoreanBeefRequestData;
+import mj.oop.controller.dto.KoreanBeefResponseData;
+import mj.oop.controller.interfaces.ProductCreateController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+
+@RestController
+public class KoreanBeefCreateController implements ProductCreateController<KoreanBeefResponseData, KoreanBeefRequestData> {
+    @PostMapping("/beef")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Override
+    public KoreanBeefResponseData create(@RequestBody KoreanBeefRequestData requestDto) {
+        return new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(1000), "1+");
+    }
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefDeleteController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefDeleteController.java
@@ -1,5 +1,7 @@
 package mj.oop.controller;
 
+import mj.oop.application.KoreanBeefDeleteService;
+import mj.oop.application.interfaces.ProductDeleteService;
 import mj.oop.controller.interfaces.ProductDeleteController;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -7,15 +9,17 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class KoreanBeefDeleteController implements ProductDeleteController {
-//    private final ProductDeleteService service;
-//    public KoreanBeefDeleteController(KoreanBeefDeleteService service) {
-//        this.service = service;
-//    }
+    private final ProductDeleteService service;
+
+    public KoreanBeefDeleteController(KoreanBeefDeleteService service) {
+        this.service = service;
+    }
 
     @DeleteMapping("/beef/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Override
     public void delete(@PathVariable Long id) {
+        service.deleteBy(id);
     }
 
 }

--- a/src/main/java/mj/oop/controller/KoreanBeefDeleteController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefDeleteController.java
@@ -1,0 +1,21 @@
+package mj.oop.controller;
+
+import mj.oop.controller.interfaces.ProductDeleteController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+public class KoreanBeefDeleteController implements ProductDeleteController {
+//    private final ProductDeleteService service;
+//    public KoreanBeefDeleteController(KoreanBeefDeleteService service) {
+//        this.service = service;
+//    }
+
+    @DeleteMapping("/beef/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Override
+    public void delete(@PathVariable Long id) {
+    }
+
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefDetailController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefDetailController.java
@@ -1,0 +1,21 @@
+package mj.oop.controller;
+
+import mj.oop.application.KoreanBeefShowService;
+import mj.oop.application.interfaces.ProductShowService;
+import mj.oop.controller.dto.KoreanBeefResponseData;
+import mj.oop.controller.interfaces.ProductDetailController;
+import mj.oop.domain.entity.KoreanBeef;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+
+@RestController
+public class KoreanBeefDetailController implements ProductDetailController<KoreanBeefResponseData> {
+    @GetMapping("/beef/{id}")
+    @Override
+    public KoreanBeefResponseData detail(@PathVariable Long id) {
+        return new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(1000), "1+");
+    }
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefDetailController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefDetailController.java
@@ -9,13 +9,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 
 @RestController
 public class KoreanBeefDetailController implements ProductDetailController<KoreanBeefResponseData> {
+    private final ProductShowService<KoreanBeef> service;
+
+    public KoreanBeefDetailController(KoreanBeefShowService service) {
+        this.service = service;
+    }
+
     @GetMapping("/beef/{id}")
     @Override
     public KoreanBeefResponseData detail(@PathVariable Long id) {
-        return new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(1000), "1+");
+        KoreanBeef product = service.showBy(id);
+        return KoreanBeefResponseData.from(product);
     }
 }

--- a/src/main/java/mj/oop/controller/KoreanBeefListController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefListController.java
@@ -8,7 +8,6 @@ import mj.oop.domain.entity.KoreanBeef;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/mj/oop/controller/KoreanBeefListController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefListController.java
@@ -1,0 +1,18 @@
+package mj.oop.controller;
+
+import mj.oop.controller.dto.KoreanBeefResponseData;
+import mj.oop.controller.interfaces.ProductListController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@RestController
+public class KoreanBeefListController implements ProductListController<KoreanBeefResponseData> {
+    @GetMapping("/beef")
+    @Override
+    public List<KoreanBeefResponseData> list() {
+        return List.of(new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(100), "1+"));
+    }
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefListController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefListController.java
@@ -1,18 +1,30 @@
 package mj.oop.controller;
 
+import mj.oop.application.KoreanBeefShowService;
+import mj.oop.application.interfaces.ProductShowService;
 import mj.oop.controller.dto.KoreanBeefResponseData;
 import mj.oop.controller.interfaces.ProductListController;
+import mj.oop.domain.entity.KoreanBeef;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class KoreanBeefListController implements ProductListController<KoreanBeefResponseData> {
+    private final ProductShowService<KoreanBeef> service;
+
+    public KoreanBeefListController(KoreanBeefShowService service) {
+        this.service = service;
+    }
+
     @GetMapping("/beef")
     @Override
     public List<KoreanBeefResponseData> list() {
-        return List.of(new KoreanBeefResponseData(1L, "맛있는 한우", new BigDecimal(100), "1+"));
+        return service.showAll().stream()
+                .map(KoreanBeefResponseData::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/mj/oop/controller/KoreanBeefUpdateController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefUpdateController.java
@@ -1,0 +1,19 @@
+package mj.oop.controller;
+
+import mj.oop.controller.dto.KoreanBeefRequestData;
+import mj.oop.controller.dto.KoreanBeefResponseData;
+import mj.oop.controller.interfaces.ProductUpdateController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.math.BigDecimal;
+
+@RestController
+public class KoreanBeefUpdateController implements ProductUpdateController<KoreanBeefResponseData, KoreanBeefRequestData> {
+
+    @PatchMapping("/beef/{id}")
+    @Override
+    public KoreanBeefResponseData update(@PathVariable Long id, @RequestBody @Valid KoreanBeefRequestData requestData) {
+        return new KoreanBeefResponseData(id, "맛있는 한우", new BigDecimal(1000), "1+");
+    }
+}

--- a/src/main/java/mj/oop/controller/KoreanBeefUpdateController.java
+++ b/src/main/java/mj/oop/controller/KoreanBeefUpdateController.java
@@ -1,19 +1,27 @@
 package mj.oop.controller;
 
+import mj.oop.application.KoreanBeefUpdateService;
+import mj.oop.application.interfaces.ProductUpdateService;
 import mj.oop.controller.dto.KoreanBeefRequestData;
 import mj.oop.controller.dto.KoreanBeefResponseData;
 import mj.oop.controller.interfaces.ProductUpdateController;
+import mj.oop.domain.entity.KoreanBeef;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.math.BigDecimal;
 
 @RestController
 public class KoreanBeefUpdateController implements ProductUpdateController<KoreanBeefResponseData, KoreanBeefRequestData> {
+    private final ProductUpdateService<KoreanBeef> service;
+
+    public KoreanBeefUpdateController(KoreanBeefUpdateService service) {
+        this.service = service;
+    }
 
     @PatchMapping("/beef/{id}")
     @Override
     public KoreanBeefResponseData update(@PathVariable Long id, @RequestBody @Valid KoreanBeefRequestData requestData) {
-        return new KoreanBeefResponseData(id, "맛있는 한우", new BigDecimal(1000), "1+");
+        KoreanBeef product = service.update(id, requestData.toEntity());
+        return KoreanBeefResponseData.from(product);
     }
 }

--- a/src/main/java/mj/oop/controller/dto/ExceptionResponse.java
+++ b/src/main/java/mj/oop/controller/dto/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package mj.oop.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ExceptionResponse {
+    private final String message;
+
+    public ExceptionResponse(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
+++ b/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
@@ -21,4 +21,11 @@ public class KoreanBeefRequestData extends ProductRequestData {
         super(name, price);
         this.meatGrade = meatGrade;
     }
+
+    public KoreanBeef toEntity() {
+        return KoreanBeef.builder()
+                .name(getName())
+                .price(getPrice())
+                .meatGrade(getMeatGrade()).build();
+    }
 }

--- a/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
+++ b/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mj.oop.domain.entity.KoreanBeef;
 
+import javax.validation.constraints.NotBlank;
 import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class KoreanBeefRequestData extends ProductRequestData {
+    @NotBlank
     private String meatGrade;
 
     @Builder

--- a/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
+++ b/src/main/java/mj/oop/controller/dto/KoreanBeefRequestData.java
@@ -1,0 +1,22 @@
+package mj.oop.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mj.oop.domain.entity.KoreanBeef;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KoreanBeefRequestData extends ProductRequestData {
+    private String meatGrade;
+
+    @Builder
+    public KoreanBeefRequestData(String name, BigDecimal price, String meatGrade) {
+        super(name, price);
+        this.meatGrade = meatGrade;
+    }
+}

--- a/src/main/java/mj/oop/controller/dto/KoreanBeefResponseData.java
+++ b/src/main/java/mj/oop/controller/dto/KoreanBeefResponseData.java
@@ -1,0 +1,12 @@
+package mj.oop.controller.dto;
+
+import java.math.BigDecimal;
+
+public class KoreanBeefResponseData extends ProductResponseData {
+    private final String meatGrade;
+
+    public KoreanBeefResponseData(Long id, String name, BigDecimal price, String meatGrade) {
+        super(id, name, price);
+        this.meatGrade = meatGrade;
+    }
+}

--- a/src/main/java/mj/oop/controller/dto/KoreanBeefResponseData.java
+++ b/src/main/java/mj/oop/controller/dto/KoreanBeefResponseData.java
@@ -1,5 +1,7 @@
 package mj.oop.controller.dto;
 
+import mj.oop.domain.entity.KoreanBeef;
+
 import java.math.BigDecimal;
 
 public class KoreanBeefResponseData extends ProductResponseData {
@@ -8,5 +10,9 @@ public class KoreanBeefResponseData extends ProductResponseData {
     public KoreanBeefResponseData(Long id, String name, BigDecimal price, String meatGrade) {
         super(id, name, price);
         this.meatGrade = meatGrade;
+    }
+
+    public static KoreanBeefResponseData from(KoreanBeef product) {
+        return new KoreanBeefResponseData(product.getId(), product.getName(), product.getPrice(), product.getMeatGrade());
     }
 }

--- a/src/main/java/mj/oop/controller/dto/ProductRequestData.java
+++ b/src/main/java/mj/oop/controller/dto/ProductRequestData.java
@@ -4,13 +4,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class ProductRequestData {
+    @NotBlank
     private String name;
 
+    @NotNull
     private BigDecimal price;
 }

--- a/src/main/java/mj/oop/controller/dto/ProductRequestData.java
+++ b/src/main/java/mj/oop/controller/dto/ProductRequestData.java
@@ -1,0 +1,16 @@
+package mj.oop.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class ProductRequestData {
+    private String name;
+
+    private BigDecimal price;
+}

--- a/src/main/java/mj/oop/controller/dto/ProductResponseData.java
+++ b/src/main/java/mj/oop/controller/dto/ProductResponseData.java
@@ -1,0 +1,18 @@
+package mj.oop.controller.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class ProductResponseData {
+    private Long id;
+
+    private String name;
+
+    private BigDecimal price;
+}

--- a/src/main/java/mj/oop/controller/interfaces/ProductCreateController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductCreateController.java
@@ -1,0 +1,24 @@
+package mj.oop.controller.interfaces;
+
+
+import mj.oop.controller.KoreanBeefCreateController;
+import mj.oop.controller.dto.ProductRequestData;
+import mj.oop.controller.dto.ProductResponseData;
+
+/**
+ * Product 타입을 상속하는 객체에 대한 생성 요청을 받아서 처리결과를 응답으로 반환한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefCreateController
+ * </p>
+ */
+public interface ProductCreateController<T extends ProductResponseData, T2 extends ProductRequestData> {
+    /**
+     * 상세 조회 요청에 따른 처리 결과를 ProductResponseData 타입으로 가공하여 반환한다
+     * <p>
+     * @param requestDto Request Body로 전달된 JSON 객체를 직렬화하여 받기 위한 객체
+     * @return 생성 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
+     * </p>
+     */
+    T create(T2 requestDto);
+}

--- a/src/main/java/mj/oop/controller/interfaces/ProductCreateController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductCreateController.java
@@ -14,7 +14,7 @@ import mj.oop.controller.dto.ProductResponseData;
  */
 public interface ProductCreateController<T extends ProductResponseData, T2 extends ProductRequestData> {
     /**
-     * 상세 조회 요청에 따른 처리 결과를 ProductResponseData 타입으로 가공하여 반환한다
+     * 생성 요청에 따른 처리 결과를 ProductResponseData 타입으로 가공하여 반환한다
      * <p>
      * @param requestDto Request Body로 전달된 JSON 객체를 직렬화하여 받기 위한 객체
      * @return 생성 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체

--- a/src/main/java/mj/oop/controller/interfaces/ProductDeleteController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductDeleteController.java
@@ -1,0 +1,21 @@
+package mj.oop.controller.interfaces;
+
+
+import mj.oop.controller.KoreanBeefDeleteController;
+
+/**
+ * Product 타입 객체에 대한 삭제 조회 요청을 받는다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefDeleteController
+ * </p>
+ */
+public interface ProductDeleteController {
+    /**
+     * 삭제 요청을 수신하여 관련 프로세스에 넘긴다. 처리결과를 반환하지 않는다.
+     * <p>
+     * @param id Request Path Parameter 전달된 Product Id
+     * </p>
+     */
+    void delete(Long id);
+}

--- a/src/main/java/mj/oop/controller/interfaces/ProductDetailController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductDetailController.java
@@ -1,0 +1,23 @@
+package mj.oop.controller.interfaces;
+
+
+import mj.oop.controller.KoreanBeefDetailController;
+import mj.oop.controller.dto.ProductResponseData;
+
+/**
+ * Product 타입을 상속하는 객체에 대한 상세 조회 요청을 받아서 처리결과를 응답으로 반환한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefDetailController
+ * </p>
+ */
+public interface ProductDetailController<T extends ProductResponseData> {
+    /**
+     * 상세 조회 요청에 따른 처리 결과를 ProductResponseData 타입으로 가공하여 반환한다
+     * <p>
+     * @param id Request Path Parameter 전달된 Product Id
+     * @return 상세 조회 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
+     * </p>
+     */
+    T detail(Long id);
+}

--- a/src/main/java/mj/oop/controller/interfaces/ProductListController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductListController.java
@@ -15,9 +15,9 @@ import java.util.List;
  */
 public interface ProductListController<T extends ProductResponseData> {
     /**
-     * 목록 조회 요청에 따른 처리 결과를 List<ProductResponseData> 형태로 가공하여 반환한다
+     * 목록 조회 요청에 따른 처리 결과를 List<ProductResponseData> 타입으로 가공하여 반환한다
      * <p>
-     * @return  목록 조회 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
+     * @return 목록 조회 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
      * </p>
      */
     List<T> list();

--- a/src/main/java/mj/oop/controller/interfaces/ProductListController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductListController.java
@@ -1,0 +1,24 @@
+package mj.oop.controller.interfaces;
+
+
+import mj.oop.controller.KoreanBeefListController;
+import mj.oop.controller.dto.ProductResponseData;
+
+import java.util.List;
+
+/**
+ * Product 타입을 상속하는 객체에 대한 목록 조회 요청을 받아서 처리결과를 응답으로 반환한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefListController
+ * </p>
+ */
+public interface ProductListController<T extends ProductResponseData> {
+    /**
+     * 목록 조회 요청에 따른 처리 결과를 List<ProductResponseData> 형태로 가공하여 반환한다
+     * <p>
+     * @return  목록 조회 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
+     * </p>
+     */
+    List<T> list();
+}

--- a/src/main/java/mj/oop/controller/interfaces/ProductUpdateController.java
+++ b/src/main/java/mj/oop/controller/interfaces/ProductUpdateController.java
@@ -1,0 +1,24 @@
+package mj.oop.controller.interfaces;
+
+import mj.oop.controller.KoreanBeefUpdateController;
+import mj.oop.controller.dto.ProductRequestData;
+import mj.oop.controller.dto.ProductResponseData;
+
+/**
+ * Product 타입을 상속하는 객체에 대한 수정 요청을 받아서 처리결과를 응답으로 반환한다
+ * <p>
+ * All Known Implementing Classes:
+ * @see KoreanBeefUpdateController
+ * </p>
+ */
+public interface ProductUpdateController<T extends ProductResponseData, T2 extends ProductRequestData> {
+    /**
+     * 수정 요청에 따른 처리 결과를 ProductResponseData 타입으로 가공하여 반환한다
+     * <p>
+     * @param id          Request Path Parameter 전달된 Product Id
+     * @param requestData Request Body로 전달된 JSON 객체를 직렬화하여 받기 위한 객체
+     * @return 수정 요청에 대한 처리결과를 JSON 객체로 역직렬화하기 위한 객체
+     * </p>
+     */
+    T update(Long id, T2 requestData);
+}

--- a/src/main/java/mj/oop/domain/entity/KoreanBeef.java
+++ b/src/main/java/mj/oop/domain/entity/KoreanBeef.java
@@ -1,0 +1,29 @@
+package mj.oop.domain.entity;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@DiscriminatorValue("KoreanBeef")
+public class KoreanBeef extends Product {
+    private String meatGrade;
+
+    @Builder
+    public KoreanBeef(Long id, String name, BigDecimal price, String meatGrade) {
+        super(id, name, price);
+        this.meatGrade = meatGrade;
+    }
+
+    @Builder
+    public KoreanBeef(String name, BigDecimal price, String meatGrade) {
+        super(name, price);
+        this.meatGrade = meatGrade;
+    }
+}

--- a/src/main/java/mj/oop/domain/entity/Product.java
+++ b/src/main/java/mj/oop/domain/entity/Product.java
@@ -1,0 +1,41 @@
+package mj.oop.domain.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+
+/**
+ * '상품'에 대한 최상위 엔티티
+ * <p>
+ * All Known Extending Classes:
+ * @see KoreanBeef
+ * </p>
+ */
+@Entity
+@Getter
+@NoArgsConstructor
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+public abstract class Product {
+    @Id
+    @GeneratedValue
+    private Long id;
+    
+    private String name;
+
+    private BigDecimal price;
+
+    public Product(Long id, String name, BigDecimal price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+
+    public Product(String name, BigDecimal price) {
+        this.name = name;
+        this.price = price;
+    }
+
+}

--- a/src/main/java/mj/oop/infra/JpaKoreanBeefRepository.java
+++ b/src/main/java/mj/oop/infra/JpaKoreanBeefRepository.java
@@ -1,0 +1,17 @@
+package mj.oop.infra;
+
+import mj.oop.domain.entity.KoreanBeef;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaKoreanBeefRepository extends CrudRepository<KoreanBeef, Long> {
+    List<KoreanBeef> findAll();
+
+    Optional<KoreanBeef> findById(Long id);
+
+    KoreanBeef save(KoreanBeef product);
+
+    void delete(KoreanBeef product);
+}

--- a/src/main/java/mj/oop/infra/KoreanBeefJpaRepository.java
+++ b/src/main/java/mj/oop/infra/KoreanBeefJpaRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.CrudRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface JpaKoreanBeefRepository extends CrudRepository<KoreanBeef, Long> {
+public interface KoreanBeefJpaRepository extends CrudRepository<KoreanBeef, Long> {
     List<KoreanBeef> findAll();
 
     Optional<KoreanBeef> findById(Long id);

--- a/src/main/java/mj/oop/infra/KoreanBeefJpaRepository.java
+++ b/src/main/java/mj/oop/infra/KoreanBeefJpaRepository.java
@@ -14,4 +14,6 @@ public interface KoreanBeefJpaRepository extends CrudRepository<KoreanBeef, Long
     KoreanBeef save(KoreanBeef product);
 
     void delete(KoreanBeef product);
+
+    boolean existsById(Long id);
 }

--- a/src/test/java/mj/oop/application/KoreanBeefCreateServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefCreateServiceTest.java
@@ -1,5 +1,6 @@
 package mj.oop.application;
 
+import mj.oop.application.interfaces.ProductCreateService;
 import mj.oop.domain.entity.KoreanBeef;
 import mj.oop.infra.KoreanBeefJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +18,7 @@ import static org.mockito.Mockito.mock;
 @DisplayName("KoreanBeefCreateService")
 class KoreanBeefCreateServiceTest {
     private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
-    private KoreanBeefCreateService service;
+    private ProductCreateService<KoreanBeef> service;
     private KoreanBeef productWithoutId;
     private KoreanBeef product;
 

--- a/src/test/java/mj/oop/application/KoreanBeefCreateServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefCreateServiceTest.java
@@ -1,0 +1,67 @@
+package mj.oop.application;
+
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("KoreanBeefCreateService")
+class KoreanBeefCreateServiceTest {
+    private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
+    private KoreanBeefCreateService service;
+    private KoreanBeef productWithoutId;
+    private KoreanBeef product;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        service = new KoreanBeefCreateService(repository);
+
+        productWithoutId = KoreanBeef.builder()
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+
+        product = KoreanBeef.builder()
+                .id(PRODUCT_ID)
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("create 메소드는")
+    class Describe_create {
+        private KoreanBeef subject() {
+            return service.create(productWithoutId);
+        }
+
+        @BeforeEach
+        void setUp() {
+            given(repository.save(any(KoreanBeef.class))).willReturn(product);
+        }
+
+        @Test
+        @DisplayName("매개변수로 전달한 값이 반영된 한우 상품 엔티티를 반환한다")
+        void it_returns_product_reflecting_params() {
+            assertThat(subject().getName()).isEqualTo(PRODUCT_NAME);
+            assertThat(subject().getPrice()).isEqualTo(PRICE);
+            assertThat(subject().getMeatGrade()).isEqualTo(MEAT_GRADE);
+        }
+    }
+}

--- a/src/test/java/mj/oop/application/KoreanBeefDeleteServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefDeleteServiceTest.java
@@ -1,0 +1,64 @@
+package mj.oop.application;
+
+import mj.oop.application.interfaces.ProductDeleteService;
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+
+@DisplayName("KoreanBeefDeleteService")
+class KoreanBeefDeleteServiceTest {
+    private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
+    private ProductDeleteService service;
+    private KoreanBeef product;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
+
+    @BeforeEach
+    void setUp() {
+        service = new KoreanBeefDeleteService(repository);
+    }
+
+    @Nested
+    @DisplayName("deleteBy 메소드는")
+    class Describe_deleteBy {
+        abstract class ContextDeletingExisting {
+            void withExisting() {
+                service.deleteBy(PRODUCT_ID);
+            }
+        }
+
+        abstract class ContextDeletingNotExisting {
+            void withoutExisting() {
+                service.deleteBy(PRODUCT_ID_NOT_EXISTING);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하는 상품을 삭제한다면")
+        class Context_with_existing_product extends ContextDeletingExisting {
+            @BeforeEach
+            void setUp() {
+                given(repository.existsById(PRODUCT_ID)).willReturn(Boolean.TRUE);
+            }
+
+            @Test
+            @DisplayName("값을 반환하지 않는다")
+            void it_returns_nothing() {
+                withExisting();
+            }
+        }
+    }
+}

--- a/src/test/java/mj/oop/application/KoreanBeefDeleteServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefDeleteServiceTest.java
@@ -1,15 +1,15 @@
 package mj.oop.application;
 
 import mj.oop.application.interfaces.ProductDeleteService;
-import mj.oop.domain.entity.KoreanBeef;
 import mj.oop.infra.KoreanBeefJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
+import java.util.NoSuchElementException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -18,11 +18,6 @@ import static org.mockito.Mockito.mock;
 class KoreanBeefDeleteServiceTest {
     private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
     private ProductDeleteService service;
-    private KoreanBeef product;
-
-    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
-    private final BigDecimal PRICE = new BigDecimal(1000);
-    private final String MEAT_GRADE = "1+";
     private final Long PRODUCT_ID = 1L;
     private final Long PRODUCT_ID_NOT_EXISTING = 100L;
 
@@ -58,6 +53,22 @@ class KoreanBeefDeleteServiceTest {
             @DisplayName("값을 반환하지 않는다")
             void it_returns_nothing() {
                 withExisting();
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 상품을 삭제한다면")
+        class Context_with_not_existing_product extends ContextDeletingNotExisting {
+            @BeforeEach
+            void setUp() {
+                given(repository.existsById(PRODUCT_ID_NOT_EXISTING)).willReturn(Boolean.FALSE);
+            }
+
+            @Test
+            @DisplayName("예외를 발생시킨다")
+            void it_throws_exception() {
+                assertThatThrownBy(this::withoutExisting)
+                        .isInstanceOf(NoSuchElementException.class);
             }
         }
     }

--- a/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
@@ -1,0 +1,77 @@
+package mj.oop.application;
+
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("KoreanBeefShowService")
+class KoreanBeefShowServiceTest {
+    private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
+    private KoreanBeefShowService service;
+    private KoreanBeef product;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        service = new KoreanBeefShowService(repository);
+
+        product = KoreanBeef.builder()
+                .id(PRODUCT_ID)
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("showAll 메소드는")
+    class Describe_showAll {
+        private List<KoreanBeef> subject() {
+            return service.showAll();
+        }
+
+        @Nested
+        @DisplayName("만약 상품이 존재하지 않는다면")
+        class Context_without_existing_product {
+            @BeforeEach
+            void setUp() {
+                given(repository.findAll()).willReturn(List.of());
+            }
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다")
+            void it_returns_empty_list() {
+                assertThat(subject()).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 상품이 존재한다면")
+        class Context_with_existing_product {
+            @BeforeEach
+            void setUp() {
+                given(repository.findAll()).willReturn(List.of(product));
+            }
+
+            @Test
+            @DisplayName("비어 있지 않은 리스트를 반환한다")
+            void it_returns_not_empty_list() {
+                assertThat(subject()).isNotEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
@@ -9,8 +9,11 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -24,6 +27,7 @@ class KoreanBeefShowServiceTest {
     private final BigDecimal PRICE = new BigDecimal(1000);
     private final String MEAT_GRADE = "1+";
     private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
 
     @BeforeEach
     void setUp() {
@@ -72,6 +76,49 @@ class KoreanBeefShowServiceTest {
             void it_returns_not_empty_list() {
                 assertThat(subject()).isNotEmpty();
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("showBy 메소드는")
+    class Describe_showBy {
+        abstract class ContextShowingByExisting {
+            KoreanBeef withExisting() {
+                return service.showBy(PRODUCT_ID);
+            }
+        }
+
+        abstract class ContextShowingByNotExisting {
+            void withoutExisting() {
+                service.showBy(PRODUCT_ID_NOT_EXISTING);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하는 상품의 ID를 전달 받는다면")
+        class Context_with_existing extends ContextShowingByExisting {
+            @BeforeEach
+            void setUp() {
+                given(repository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
+            }
+
+            @Test
+            @DisplayName("전달 받은 Id에 해당하는 상품을 반환한다")
+            void it_returns_product_having_id_equal_to_param() {
+                assertThat(withExisting().getId()).isEqualTo(PRODUCT_ID);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 상품의 ID를 전달 받는다면")
+        class Context_with_not_existing extends ContextShowingByNotExisting {
+            @Test
+            @DisplayName("예외를 발생시킨다")
+            void it_throws_exception() {
+                assertThatThrownBy(this::withoutExisting)
+                        .isInstanceOf(NoSuchElementException.class);
+            }
+
         }
     }
 }

--- a/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefShowServiceTest.java
@@ -1,5 +1,6 @@
 package mj.oop.application;
 
+import mj.oop.application.interfaces.ProductShowService;
 import mj.oop.domain.entity.KoreanBeef;
 import mj.oop.infra.KoreanBeefJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.mock;
 @DisplayName("KoreanBeefShowService")
 class KoreanBeefShowServiceTest {
     private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
-    private KoreanBeefShowService service;
+    private ProductShowService<KoreanBeef> service;
     private KoreanBeef product;
 
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";

--- a/src/test/java/mj/oop/application/KoreanBeefUpdateServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefUpdateServiceTest.java
@@ -1,5 +1,6 @@
 package mj.oop.application;
 
+import mj.oop.application.interfaces.ProductUpdateService;
 import mj.oop.domain.entity.KoreanBeef;
 import mj.oop.infra.KoreanBeefJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +18,7 @@ import static org.mockito.Mockito.mock;
 @DisplayName("KoreanBeefUpdateService")
 class KoreanBeefUpdateServiceTest {
     private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
-    private KoreanBeefUpdateService service;
+    private ProductUpdateService<KoreanBeef> service;
     private KoreanBeef product;
 
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";

--- a/src/test/java/mj/oop/application/KoreanBeefUpdateServiceTest.java
+++ b/src/test/java/mj/oop/application/KoreanBeefUpdateServiceTest.java
@@ -1,0 +1,87 @@
+package mj.oop.application;
+
+import mj.oop.domain.entity.KoreanBeef;
+import mj.oop.infra.KoreanBeefJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("KoreanBeefUpdateService")
+class KoreanBeefUpdateServiceTest {
+    private final KoreanBeefJpaRepository repository = mock(KoreanBeefJpaRepository.class);
+    private KoreanBeefUpdateService service;
+    private KoreanBeef product;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
+
+    @BeforeEach
+    void setUp() {
+        service = new KoreanBeefUpdateService(repository);
+
+        product = KoreanBeef.builder()
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("update 메소드는")
+    class Describe_update {
+        abstract class ContextUpdatingExisting {
+            KoreanBeef withExisting() {
+                return service.update(PRODUCT_ID, product);
+            }
+        }
+
+        abstract class ContextUpdatingNotExisting {
+            void withoutExisting() {
+                service.update(PRODUCT_ID_NOT_EXISTING, product);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하는 상을 수정한다면")
+        class Context_with_existing extends ContextUpdatingExisting {
+            @BeforeEach
+            void setUp() {
+                given(repository.existsById(PRODUCT_ID)).willReturn(Boolean.TRUE);
+                given(repository.save(any(KoreanBeef.class))).will(invocation -> {
+                    KoreanBeef source = invocation.getArgument(0);
+                    return KoreanBeef.builder()
+                            .id(PRODUCT_ID)
+                            .name(source.getName())
+                            .price(source.getPrice())
+                            .meatGrade(source.getMeatGrade())
+                            .build();
+                });
+            }
+
+            @Test
+            @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 User를 반환한다")
+            void it_returns_product_having_id_equal_to_param() {
+                assertThat(withExisting().getId()).isEqualTo(PRODUCT_ID);
+            }
+
+            @Test
+            @DisplayName("매개변수로 전달한 값이 반영된 한우 상품을 반환한다")
+            void it_returns_product_reflecting_params() {
+                assertThat(withExisting().getName()).isEqualTo(PRODUCT_NAME);
+                assertThat(withExisting().getPrice()).isEqualTo(PRICE);
+                assertThat(withExisting().getMeatGrade()).isEqualTo(MEAT_GRADE);
+            }
+        }
+    }
+}

--- a/src/test/java/mj/oop/controller/HomeControllerTest.java
+++ b/src/test/java/mj/oop/controller/HomeControllerTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -13,8 +14,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
 @AutoConfigureMockMvc
+@WebMvcTest(HomeController.class)
 @DisplayName("HomeController")
 class HomeControllerTest {
     @Autowired

--- a/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
@@ -50,7 +50,7 @@ class KoreanBeefCreateControllerTest {
 
         @Nested
         @DisplayName("유효한 매개변수를 전달 받는다면")
-        class Context_with_valid_param {
+        class Context_with_all_valid_params {
             @Test
             @DisplayName("HTTP Status Code 201 CREATED 응답한다")
             void it_responds_with_201() throws Exception {
@@ -58,6 +58,71 @@ class KoreanBeefCreateControllerTest {
                                 .content(jsonFrom(product))
                                 .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isCreated());
+            }
+        }
+
+        @Nested
+        @DisplayName("빈값의 이름을 받는다면")
+        class Context_with_empty_param {
+            @BeforeEach
+            void setUp() {
+                product = KoreanBeef.builder()
+                        .id(PRODUCT_ID)
+                        .name("")
+                        .price(PRICE)
+                        .meatGrade(MEAT_GRADE)
+                        .build();
+            }
+            @Test
+            @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")
+            void it_responds_with_400() throws Exception {
+                mockMvc.perform(post("/beef")
+                                .content(jsonFrom(product))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+
+        @Nested
+        @DisplayName("공백의 이름을 받는다면")
+        class Context_with_space_param {
+            @BeforeEach
+            void setUp() {
+                product = KoreanBeef.builder()
+                        .id(PRODUCT_ID)
+                        .name(" ")
+                        .price(PRICE)
+                        .meatGrade(MEAT_GRADE)
+                        .build();
+            }
+            @Test
+            @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")
+            void it_responds_with_400() throws Exception {
+                mockMvc.perform(post("/beef")
+                                .content(jsonFrom(product))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+
+        @Nested
+        @DisplayName("가격을 NULL로 받는다면")
+        class Context_with_null_price {
+            @BeforeEach
+            void setUp() {
+                product = KoreanBeef.builder()
+                        .id(PRODUCT_ID)
+                        .name(PRODUCT_NAME)
+                        .meatGrade(MEAT_GRADE)
+                        .build();
+            }
+            @Test
+            @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")
+            void it_responds_with_400() throws Exception {
+                mockMvc.perform(post("/beef")
+                                .content(jsonFrom(product))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isBadRequest());
             }
         }
     }

--- a/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
@@ -1,0 +1,74 @@
+package mj.oop.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mj.oop.controller.dto.KoreanBeefRequestData;
+import mj.oop.domain.entity.KoreanBeef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@WebMvcTest(KoreanBeefCreateController.class)
+@DisplayName("KoreanBeefCreateController")
+class KoreanBeefCreateControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+
+    private KoreanBeef product;
+
+    @Nested
+    @DisplayName("create 메소드는")
+    class Describe_create {
+        @BeforeEach
+        void setUp() {
+            product = KoreanBeef.builder()
+                    .id(PRODUCT_ID)
+                    .name(PRODUCT_NAME)
+                    .price(PRICE)
+                    .meatGrade(MEAT_GRADE)
+                    .build();
+        }
+
+        @Nested
+        @DisplayName("유효한 매개변수를 전달 받는다면")
+        class Context_with_valid_param {
+            @Test
+            @DisplayName("HTTP Status Code 201 CREATED 응답한다")
+            void it_responds_with_201() throws Exception {
+                mockMvc.perform(post("/beef")
+                                .content(jsonFrom(product))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isCreated());
+            }
+        }
+    }
+
+    private String jsonFrom(KoreanBeef product) throws JsonProcessingException {
+        KoreanBeefRequestData requestData = KoreanBeefRequestData.builder()
+                .name(product.getName())
+                .price(product.getPrice())
+                .meatGrade(product.getMeatGrade())
+                .build();
+
+        return objectMapper.writeValueAsString(requestData);
+    }
+}

--- a/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefCreateControllerTest.java
@@ -2,6 +2,7 @@ package mj.oop.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import mj.oop.application.KoreanBeefCreateService;
 import mj.oop.controller.dto.KoreanBeefRequestData;
 import mj.oop.domain.entity.KoreanBeef;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,11 +12,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(KoreanBeefCreateController.class)
 @DisplayName("KoreanBeefCreateController")
 class KoreanBeefCreateControllerTest {
+    @MockBean
+    private KoreanBeefCreateService service;
     @Autowired
     private MockMvc mockMvc;
     @Autowired
@@ -46,6 +52,8 @@ class KoreanBeefCreateControllerTest {
                     .price(PRICE)
                     .meatGrade(MEAT_GRADE)
                     .build();
+
+            given(service.create(any(KoreanBeef.class))).willReturn(product);
         }
 
         @Nested
@@ -72,6 +80,8 @@ class KoreanBeefCreateControllerTest {
                         .price(PRICE)
                         .meatGrade(MEAT_GRADE)
                         .build();
+
+                given(service.create(any(KoreanBeef.class))).willReturn(product);
             }
             @Test
             @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")
@@ -94,6 +104,8 @@ class KoreanBeefCreateControllerTest {
                         .price(PRICE)
                         .meatGrade(MEAT_GRADE)
                         .build();
+
+                given(service.create(any(KoreanBeef.class))).willReturn(product);
             }
             @Test
             @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")
@@ -115,6 +127,8 @@ class KoreanBeefCreateControllerTest {
                         .name(PRODUCT_NAME)
                         .meatGrade(MEAT_GRADE)
                         .build();
+
+                given(service.create(any(KoreanBeef.class))).willReturn(product);
             }
             @Test
             @DisplayName("HTTP Status Code 400 BAD REQUEST 응답한다")

--- a/src/test/java/mj/oop/controller/KoreanBeefDeleteControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefDeleteControllerTest.java
@@ -1,15 +1,21 @@
 package mj.oop.controller;
 
 
+import mj.oop.application.KoreanBeefDeleteService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 
+import java.util.NoSuchElementException;
+
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -18,10 +24,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(KoreanBeefDeleteController.class)
 @DisplayName("KoreanBeefDeleteController")
 class KoreanBeefDeleteControllerTest {
+    @MockBean
+    private KoreanBeefDeleteService service;
     @Autowired
     private MockMvc mockMvc;
 
     private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
 
     @Nested
     @DisplayName("delete 메소드는")
@@ -36,5 +45,25 @@ class KoreanBeefDeleteControllerTest {
                         .andExpect(status().isNoContent());
             }
         }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 ID를 매개변수로 전달 받는다면")
+        class Context_without_existing_product {
+            @BeforeEach
+            void setUp() {
+                willThrow(new NoSuchElementException(PRODUCT_ID_NOT_EXISTING.toString()))
+                        .given(service).deleteBy(PRODUCT_ID_NOT_EXISTING);
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(delete("/beef/" + PRODUCT_ID_NOT_EXISTING))
+                        .andExpect(status().isNotFound());
+            }
+
+        }
     }
+
+
 }

--- a/src/test/java/mj/oop/controller/KoreanBeefDeleteControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefDeleteControllerTest.java
@@ -1,0 +1,40 @@
+package mj.oop.controller;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@AutoConfigureMockMvc
+@WebMvcTest(KoreanBeefDeleteController.class)
+@DisplayName("KoreanBeefDeleteController")
+class KoreanBeefDeleteControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final Long PRODUCT_ID = 1L;
+
+    @Nested
+    @DisplayName("delete 메소드는")
+    class Describe_delete {
+        @Nested
+        @DisplayName("유효한 매개변수를 전달 받는다면")
+        class Context_with_valid_param {
+            @Test
+            @DisplayName("HTTP Status Code 204 NO CONTENT 응답한다")
+            void it_responds_with_204() throws Exception {
+                mockMvc.perform(delete("/beef/" + PRODUCT_ID))
+                        .andExpect(status().isNoContent());
+            }
+        }
+    }
+}

--- a/src/test/java/mj/oop/controller/KoreanBeefDetailControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefDetailControllerTest.java
@@ -30,8 +30,6 @@ class KoreanBeefDetailControllerTest {
     private KoreanBeefShowService service;
     @Autowired
     private MockMvc mockMvc;
-    @Autowired
-    private ObjectMapper objectMapper;
 
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
     private final BigDecimal PRICE = new BigDecimal(1000);

--- a/src/test/java/mj/oop/controller/KoreanBeefDetailControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefDetailControllerTest.java
@@ -1,0 +1,65 @@
+package mj.oop.controller;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mj.oop.domain.entity.KoreanBeef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@AutoConfigureMockMvc
+@WebMvcTest(KoreanBeefDetailController.class)
+@DisplayName("KoreanBeefDetailController")
+class KoreanBeefDetailControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
+
+    private KoreanBeef product;
+
+    @BeforeEach
+    void setUp() {
+        product = KoreanBeef.builder()
+                .id(PRODUCT_ID)
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("detail 메소드는")
+    class Describe_detail {
+        @Nested
+        @DisplayName("유효한 매개변수를 전달 받는다면")
+        class Context_with_valid_param {
+            @Test
+            @DisplayName("HTTP Status Code 200 OK 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(get("/beef/" + PRODUCT_ID))
+                        .andExpect(status().isOk());
+            }
+        }
+    }
+}

--- a/src/test/java/mj/oop/controller/KoreanBeefListControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefListControllerTest.java
@@ -1,6 +1,6 @@
 package mj.oop.controller;
 
-import mj.oop.application.interfaces.ProductShowService;
+import mj.oop.application.KoreanBeefShowService;
 import mj.oop.domain.entity.KoreanBeef;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +24,7 @@ class KoreanBeefListControllerTest {
     @Autowired
     private MockMvc mockMvc;
     @MockBean
-    private ProductShowService<KoreanBeef> service;
+    private KoreanBeefShowService service;
 
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
     private final BigDecimal PRICE = new BigDecimal(1000);

--- a/src/test/java/mj/oop/controller/KoreanBeefListControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefListControllerTest.java
@@ -1,0 +1,58 @@
+package mj.oop.controller;
+
+import mj.oop.application.interfaces.ProductShowService;
+import mj.oop.domain.entity.KoreanBeef;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@WebMvcTest(KoreanBeefListController.class)
+@DisplayName("KoreanBeefListController")
+class KoreanBeefListControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private ProductShowService<KoreanBeef> service;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+
+    private KoreanBeef product;
+
+    @Nested
+    @DisplayName("list 메소드는")
+    class Describe_list {
+        @BeforeEach
+        void setUp() {
+            product = KoreanBeef.builder()
+                    .id(PRODUCT_ID)
+                    .name(PRODUCT_NAME)
+                    .price(PRICE)
+                    .meatGrade(MEAT_GRADE)
+                    .build();
+
+            given(service.showAll()).willReturn(List.of(product));
+        }
+
+        @Test
+        @DisplayName("HTTP Status Code 200 OK 응답한다")
+        void it_responds_with_200_ok() throws Exception {
+            mockMvc.perform(get("/beef"))
+                    .andExpect(status().isOk());
+        }
+    }
+}

--- a/src/test/java/mj/oop/controller/KoreanBeefUpdateControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefUpdateControllerTest.java
@@ -1,0 +1,72 @@
+package mj.oop.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mj.oop.controller.dto.KoreanBeefRequestData;
+import mj.oop.domain.entity.KoreanBeef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@WebMvcTest(KoreanBeefUpdateController.class)
+@DisplayName("KoreanBeefUpdateController")
+class KoreanBeefUpdateControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+
+    private KoreanBeef product;
+
+    @Nested
+    @DisplayName("update 메소드는")
+    class Describe_update {
+        @Nested
+        @DisplayName("유효한 매개변수를 전달 받는다면")
+        class Context_with_all_valid_params {
+            @BeforeEach
+            void setUp() {
+                product = KoreanBeef.builder()
+                        .name(PRODUCT_NAME)
+                        .price(PRICE)
+                        .meatGrade(MEAT_GRADE)
+                        .build();
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 200 OK 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(patch("/beef/" + PRODUCT_ID)
+                                .content(jsonFrom(product))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk());
+            }
+        }
+    }
+
+    private String jsonFrom(KoreanBeef product) throws JsonProcessingException {
+        KoreanBeefRequestData requestData = KoreanBeefRequestData.builder()
+                .name(product.getName())
+                .price(product.getPrice())
+                .meatGrade(product.getMeatGrade())
+                .build();
+
+        return objectMapper.writeValueAsString(requestData);
+    }
+}

--- a/src/test/java/mj/oop/controller/KoreanBeefUpdateControllerTest.java
+++ b/src/test/java/mj/oop/controller/KoreanBeefUpdateControllerTest.java
@@ -2,6 +2,7 @@ package mj.oop.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import mj.oop.application.KoreanBeefUpdateService;
 import mj.oop.controller.dto.KoreanBeefRequestData;
 import mj.oop.domain.entity.KoreanBeef;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,11 +12,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -23,6 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(KoreanBeefUpdateController.class)
 @DisplayName("KoreanBeefUpdateController")
 class KoreanBeefUpdateControllerTest {
+    @MockBean
+    private KoreanBeefUpdateService service;
     @Autowired
     private MockMvc mockMvc;
     @Autowired
@@ -43,10 +50,13 @@ class KoreanBeefUpdateControllerTest {
             @BeforeEach
             void setUp() {
                 product = KoreanBeef.builder()
+                        .id(PRODUCT_ID)
                         .name(PRODUCT_NAME)
                         .price(PRICE)
                         .meatGrade(MEAT_GRADE)
                         .build();
+
+                given(service.update(eq(PRODUCT_ID), any(KoreanBeef.class))).willReturn(product);
             }
 
             @Test

--- a/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
+++ b/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
@@ -1,0 +1,76 @@
+package mj.oop.infra;
+
+import mj.oop.domain.entity.KoreanBeef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@DisplayName("JpaKoreanBeefRepository")
+class JpaKoreanBeefRepositoryTest {
+    @Autowired
+    private JpaKoreanBeefRepository repository;
+
+    private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
+    private final BigDecimal PRICE = new BigDecimal(1000);
+    private final String MEAT_GRADE = "1+";
+
+    private KoreanBeef product;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        product = KoreanBeef.builder()
+                .name(PRODUCT_NAME)
+                .price(PRICE)
+                .meatGrade(MEAT_GRADE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("findAll 메소드는")
+    class Describe_findAll {
+        private List<KoreanBeef> subject() {
+            return repository.findAll();
+        }
+
+        @Nested
+        @DisplayName("만약 상품이 존재하지 않는다면")
+        class Context_without_existing_product {
+            @Test
+            @DisplayName("비어 있는 List를 반환한다")
+            void it_returns_empty_list() {
+                final List<KoreanBeef> actual = subject();
+
+                assertThat(actual).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 상품이 존재한다면")
+        class Context_with_existing_product {
+            @BeforeEach
+            void setUp() {
+                repository.save(product);
+            }
+
+            @Test
+            @DisplayName("비어 있지 않은 List를 반환한다")
+            void it_returns_not_empty_list() {
+                final List<KoreanBeef> actual = subject();
+
+                assertThat(actual).isNotEmpty();
+            }
+        }
+    }
+
+}

--- a/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
+++ b/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
@@ -49,9 +49,7 @@ class JpaKoreanBeefRepositoryTest {
             @Test
             @DisplayName("비어 있는 List를 반환한다")
             void it_returns_empty_list() {
-                final List<KoreanBeef> actual = subject();
-
-                assertThat(actual).isEmpty();
+                assertThat(subject()).isEmpty();
             }
         }
 
@@ -66,9 +64,7 @@ class JpaKoreanBeefRepositoryTest {
             @Test
             @DisplayName("비어 있지 않은 List를 반환한다")
             void it_returns_not_empty_list() {
-                final List<KoreanBeef> actual = subject();
-
-                assertThat(actual).isNotEmpty();
+                assertThat(subject()).isNotEmpty();
             }
         }
     }

--- a/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
+++ b/src/test/java/mj/oop/infra/JpaKoreanBeefRepositoryTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,6 +23,8 @@ class JpaKoreanBeefRepositoryTest {
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
     private final BigDecimal PRICE = new BigDecimal(1000);
     private final String MEAT_GRADE = "1+";
+    private final Long PRODUCT_ID = 1L;
+    private final Long PRODUCT_ID_NOT_EXISTING = 100L;
 
     private KoreanBeef product;
 
@@ -30,6 +33,7 @@ class JpaKoreanBeefRepositoryTest {
         repository.deleteAll();
 
         product = KoreanBeef.builder()
+                .id(PRODUCT_ID)
                 .name(PRODUCT_NAME)
                 .price(PRICE)
                 .meatGrade(MEAT_GRADE)
@@ -65,6 +69,44 @@ class JpaKoreanBeefRepositoryTest {
             @DisplayName("비어 있지 않은 List를 반환한다")
             void it_returns_not_empty_list() {
                 assertThat(subject()).isNotEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("findById 메소드는")
+    class Describe_findById {
+        private Optional<KoreanBeef> subjectWithExistingId() {
+            return repository.findById(PRODUCT_ID);
+        }
+
+
+        @Nested
+        @DisplayName("존재하는 상품 아이디를 전달 받는다면")
+        class Context_with_existing_product {
+            @BeforeEach
+            void setUp() {
+                repository.save(product);
+            }
+
+            @Test
+            @DisplayName("비어 있지 않은 값을 반환한다")
+            void it_returns_not_empty() {
+                assertThat(subjectWithExistingId()).isPresent();
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 상품 아이디를 전달 받는다면")
+        class Context_without_existing_product {
+            private Optional<KoreanBeef> subjectWithNotExistingId() {
+                return repository.findById(PRODUCT_ID_NOT_EXISTING);
+            }
+
+            @Test
+            @DisplayName("빈 값을 반환한다")
+            void it_returns_empty() {
+                assertThat(subjectWithNotExistingId()).isNotPresent();
             }
         }
     }

--- a/src/test/java/mj/oop/infra/KoreanBeefJpaRepositoryTest.java
+++ b/src/test/java/mj/oop/infra/KoreanBeefJpaRepositoryTest.java
@@ -16,9 +16,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @DisplayName("JpaKoreanBeefRepository")
-class JpaKoreanBeefRepositoryTest {
+class KoreanBeefJpaRepositoryTest {
     @Autowired
-    private JpaKoreanBeefRepository repository;
+    private KoreanBeefJpaRepository repository;
 
     private final String PRODUCT_NAME = "세상에서 제일 맛있는 한우";
     private final BigDecimal PRICE = new BigDecimal(1000);


### PR DESCRIPTION
## 설계의도
### 추상 클래스 기반 '상품' 정의
- '정육점 쇼핑몰' 도메인 영역에서 '상품'이라는 상위 객체와 이를 상속하는 하위 객체로 모든 상품을 설계할 수 있다고 판단
- '상품' 객체과 그 하위 객체의 관계는 모두 is-a가 될 것으로 판단
- '상품' 도메인에 대한 최상위 객체로 'Product' 추상 클래스를 정의하고, 이름과 가격을 속성값으로 정의

### '상품' 상속하여 '한우 상품' 정의
- '상품'을 상속한 '한우 상품'에는 원육등급에 해당하는 MeatGrade 속성값 추가

### Service, Controller 컴포넌트에 대한 인터페이스 정의
- '상품' 도메인을 다루는 Service, Controller는 다양한 '상품' 객체에 재사용하기 위해 Product 타입 기반의 제네렉 활용하여 정의

### 계층형 테스트 코드 적용
- 테스트 코드의 가독성 향상 및 유지보수성을 감안하여 계층형 테스트 방식 적용
